### PR TITLE
Remove event.stopPropagation in dragover so it bubbles up

### DIFF
--- a/src/dnd-dropzone.directive.ts
+++ b/src/dnd-dropzone.directive.ts
@@ -146,6 +146,15 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
   }
 
   onDragOver( event:DragEvent ) {
+    // With nested dropzones, we want to ignore this event if a child dropzone
+    // has already handled a dragover.  Historically, event.stopPropagation() was
+    // used to prevent this bubbling, but that prevents any dragovers outside the
+    // ngx-drag-drop component, and stops other use cases such as scrolling on drag.
+    // Instead, we can check if the event was already prevented by a child and bail early.
+    if( event.defaultPrevented ) {
+
+      return;
+    }
 
     // check if this drag event is allowed to drop on this dropzone
     const type = getDndType( event );
@@ -173,8 +182,6 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
     this.dndDragover.emit( event );
 
     this.renderer.addClass( this.elementRef.nativeElement, this.dndDragoverClass );
-
-    event.stopPropagation();
   }
 
   @HostListener( "drop", [ "$event" ] )


### PR DESCRIPTION
Some scrollbar libraries support scrolling on `dragover`.  This component is stopping the propagation of that event, so I've simply removed the `stopPropagation` to allow that event to bubble up.  I checked angular-drag-and-drop-lists and it looks like this same `stopPropagation` has been there [since the beginning](https://github.com/marceljuenemann/angular-drag-and-drop-lists/commit/30c7327087d64c16eae21fb50729bfe219ecb354).  I don't believe that it's entirely necessary to stop these events if they've been handled by the component, e.g. preventing it from bubbling up.