### PR TITLE
Move dragenter/dragleave events outside the angular zone

### DIFF
--- a/src/dnd-dropzone.directive.ts
+++ b/src/dnd-dropzone.directive.ts
@@ -74,7 +74,9 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
 
   private disabled:boolean = false;
 
-  private readonly dragEventHandler: (event: DragEvent) => void = (event: DragEvent) => this.onDragOver(event);
+  private readonly dragEnterEventHandler: (event: DragEvent) => void = (event: DragEvent) => this.onDragEnter(event);
+  private readonly dragOverEventHandler: (event: DragEvent) => void = (event: DragEvent) => this.onDragOver(event);
+  private readonly dragLeaveEventHandler: (event: DragEvent) => void = (event: DragEvent) => this.onDragLeave(event);
 
   @Input()
   set dndDisableIf( value:boolean ) {
@@ -105,15 +107,18 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
       this.placeholder.remove();
     }
     this.ngZone.runOutsideAngular(() => {
-      this.elementRef.nativeElement.addEventListener("dragover", this.dragEventHandler)
+      this.elementRef.nativeElement.addEventListener("dragenter", this.dragEnterEventHandler);
+      this.elementRef.nativeElement.addEventListener("dragover", this.dragOverEventHandler);
+      this.elementRef.nativeElement.addEventListener("dragleave", this.dragLeaveEventHandler);
     } );
   }
 
   ngOnDestroy(): void {
-    this.elementRef.nativeElement.removeEventListener("dragover", this.dragEventHandler);
+    this.elementRef.nativeElement.removeEventListener("dragenter", this.dragEnterEventHandler);
+    this.elementRef.nativeElement.removeEventListener("dragover", this.dragOverEventHandler);
+    this.elementRef.nativeElement.removeEventListener("dragleave", this.dragLeaveEventHandler);
   }
 
-  @HostListener( "dragenter", [ "$event" ] )
   onDragEnter( event:DndEvent ) {
 
     // check if another dropzone is activated
@@ -226,7 +231,6 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
     }
   }
 
-  @HostListener( "dragleave", [ "$event" ] )
   onDragLeave( event:DndEvent ) {
 
     // check if still inside this dropzone and not yet handled by another dropzone


### PR DESCRIPTION
This is very similar to #13.  I was doing some more diagnosis of performance with the library and I believe these two events would be beneficial to move outside the Angular Zone as well.  It seems that dragEnter/dragLeave get called on any element that supports pointer events (e.g. that can be turned off with CSS `pointer-events: none`).  I couldn't find any necessity within the functions to trigger change detection, so I believe it's fairly safe.