### PR TITLE
fix(DndDraggableDirective): Prevent dragend hook if disabled

### DIFF
--- a/projects/dnd/src/lib/dnd-draggable.directive.ts
+++ b/projects/dnd/src/lib/dnd-draggable.directive.ts
@@ -174,6 +174,9 @@ export class DndDraggableDirective implements AfterViewInit, OnDestroy {
   }
 
   @HostListener('dragend', ['$event']) onDragEnd(event: DragEvent) {
+    if (!this.draggable || !this.isDragStarted) {
+      return;
+    }
     // get drop effect from custom stored state as its not reliable across browsers
     const dropEffect = dndState.dropEffect;
 


### PR DESCRIPTION
Make sure the `dragend` hook won't be called if disabled. 