### PR TITLE
Unregistering drag handle after handle's destroy

### DIFF
--- a/projects/dnd/src/lib/dnd-handle.directive.ts
+++ b/projects/dnd/src/lib/dnd-handle.directive.ts
@@ -9,13 +9,17 @@ import { DndDraggableDirective } from './dnd-draggable.directive';
 import { DndEvent } from './dnd-utils';
 
 @Directive({ selector: '[dndHandle]', standalone: true })
-export class DndHandleDirective implements OnInit {
+export class DndHandleDirective  implements OnInit, OnDestroy {
   @HostBinding('attr.draggable') draggable = true;
 
   dndDraggableDirective = inject(DndDraggableDirective);
 
   ngOnInit() {
     this.dndDraggableDirective.registerDragHandle(this);
+  }
+
+  ngOnDestroy(): void {
+    this.dndDraggableDirective.registerDragHandle(undefined);
   }
 
   @HostListener('dragstart', ['$event'])

--- a/projects/dnd/src/lib/dnd-handle.directive.ts
+++ b/projects/dnd/src/lib/dnd-handle.directive.ts
@@ -3,13 +3,14 @@ import {
   HostBinding,
   HostListener,
   inject,
+  OnDestroy,
   OnInit,
 } from '@angular/core';
 import { DndDraggableDirective } from './dnd-draggable.directive';
 import { DndEvent } from './dnd-utils';
 
 @Directive({ selector: '[dndHandle]', standalone: true })
-export class DndHandleDirective  implements OnInit, OnDestroy {
+export class DndHandleDirective implements OnInit, OnDestroy {
   @HostBinding('attr.draggable') draggable = true;
 
   dndDraggableDirective = inject(DndDraggableDirective);


### PR DESCRIPTION
When we were destroying the drag handle's component, our draggable directive still had the handle registered, which were problematic if we wanted that the draggable element require an handle in a certain state, then no handle in another one.