### PR TITLE
Fix a bug where interacting more than 2 times in 100 milliseconds lea…

### DIFF
--- a/projects/dnd/src/lib/dnd-draggable.directive.ts
+++ b/projects/dnd/src/lib/dnd-draggable.directive.ts
@@ -163,7 +163,9 @@ export class DndDraggableDirective implements AfterViewInit, OnDestroy {
     event.stopPropagation();
 
     setTimeout(() => {
-      this.renderer.setStyle(this.dragImage, 'pointer-events', 'none');
+      if(this.isDragStarted) {
+        this.renderer.setStyle(this.dragImage, 'pointer-events', 'none');
+      }
     }, 100);
 
     return true;


### PR DESCRIPTION
…d to a persistent "pointer-events" style
If drag was stopped for any reason between the drag start and the timeout of 100 milliseconds, the "pointer-events" style was persisting indefinitely.  To fix this bug, we just need to check if we are still dragging the element when the timeout is called.
Related to #156 