### PR TITLE
fix(DndDropzoneDirective): fix placeholder appearance issue in nested-mode

### DIFF
--- a/projects/dnd/src/lib/dnd-dropzone.directive.ts
+++ b/projects/dnd/src/lib/dnd-dropzone.directive.ts
@@ -144,7 +144,7 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
 
     // set as active if the target element is inside this dropzone
     if (event._dndDropzoneActive == null) {
-      const newTarget = document.elementFromPoint(event.clientX, event.clientY);
+      const newTarget = event.target;
 
       if (this.elementRef.nativeElement.contains(newTarget)) {
         event._dndDropzoneActive = true;


### PR DESCRIPTION
while dragging item from top to bottom, the previous placeholder should get removed.
The bug can be seen on demo.

https://github.com/reppners/ngx-drag-drop/assets/43305709/bd9c6e9e-e76d-4334-99d8-4a33c41668bf

