### PR TITLE
Fix Safari bug with flickering elements on drag

### DIFF
--- a/projects/dnd/src/lib/dnd-dropzone.directive.ts
+++ b/projects/dnd/src/lib/dnd-dropzone.directive.ts
@@ -73,6 +73,8 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
 
   private disabled: boolean = false;
 
+  private enterCount: number = 0;
+
   constructor(
     private ngZone: NgZone,
     private elementRef: ElementRef,
@@ -136,6 +138,8 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
   }
 
   onDragEnter(event: DndEvent) {
+    this.enterCount++;
+
     // check if another dropzone is activated
     if (event._dndDropzoneActive === true) {
       this.cleanupDragoverState();
@@ -253,9 +257,11 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
     event.preventDefault();
     event.stopPropagation();
 
+    this.enterCount--;
+
     // check if still inside this dropzone and not yet handled by another dropzone
     if (event._dndDropzoneActive == null) {
-      if (this.elementRef.nativeElement.contains(event.relatedTarget)) {
+      if (this.enterCount !== 0) {
         event._dndDropzoneActive = true;
         return;
       }
@@ -395,6 +401,7 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
       this.dndDragoverClass
     );
 
+    this.enterCount = 0;
     this.removePlaceholderFromDOM();
   }
 }


### PR DESCRIPTION
We can not use `event.relatedTarget` to check if the native element still contains the dragged element because of a Safari bug with `NULL` as `event.relatedTarget` value on the `dragleave` event.

See [bug](https://stackoverflow.com/questions/68745781/dragevent-relatedtarget-returns-null-in-safari) on StackOverflow

The solution is to use a counter instead of the related target that decrease on drag leave and increase on drag enter.

The flickering of the elements can be tested with Safari on the [demo](https://reppners.github.io/ngx-drag-drop/simple) application (see list and typed)

Related to https://github.com/reppners/ngx-drag-drop/issues/155
