### PR TITLE
Fix dropzone for shadowdom

### DIFF
--- a/projects/dnd/src/lib/dnd-dropzone.directive.ts
+++ b/projects/dnd/src/lib/dnd-dropzone.directive.ts
@@ -144,8 +144,10 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
 
     // set as active if the target element is inside this dropzone
     if (event._dndDropzoneActive == null) {
-      const newTarget = document.elementFromPoint(event.clientX, event.clientY);
-
+      let targetDocument = this.elementRef.nativeElement.getRootNode() instanceof ShadowRoot ?
+        this.elementRef.nativeElement.getRootNode() as Document :
+        document;
+      const newTarget = targetDocument.elementFromPoint(event.clientX, event.clientY);
       if (this.elementRef.nativeElement.contains(newTarget)) {
         event._dndDropzoneActive = true;
       }


### PR DESCRIPTION
I've figured out the issue causing this bug. In the onDragEnter method of the dndDropzone directive, there's a reference to document, but in Shadow DOM mode, it doesn't locate the element correctly.
What needs to be done is perform a check and inject the correct element for document. In Shadow DOM mode, it should use something like document.querySelector()?.shadowRoot, otherwise fall back to document.

Related to https://github.com/reppners/ngx-drag-drop/issues/184