### PR TITLE
Replace deprecated substr() with substring()

### DIFF
--- a/projects/dnd/src/lib/dnd-state.ts
+++ b/projects/dnd/src/lib/dnd-state.ts
@@ -104,7 +104,7 @@ export function getDndType(event: DragEvent): string | undefined {
     return undefined;
   }
 
-  return mimeType.substr(CUSTOM_MIME_TYPE.length + 1) || undefined;
+  return mimeType.substring(CUSTOM_MIME_TYPE.length + 1) || undefined;
 }
 
 export function isExternalDrag(): boolean {

--- a/projects/dnd/src/lib/dnd-utils.ts
+++ b/projects/dnd/src/lib/dnd-utils.ts
@@ -22,7 +22,7 @@ export const JSON_MIME_TYPE = 'application/json';
 export const MSIE_MIME_TYPE = 'Text';
 
 function mimeTypeIsCustom(mimeType: string) {
-  return mimeType.substr(0, CUSTOM_MIME_TYPE.length) === CUSTOM_MIME_TYPE;
+  return mimeType.substring(0, CUSTOM_MIME_TYPE.length) === CUSTOM_MIME_TYPE;
 }
 
 export function getWellKnownMimeType(event: DragEvent): string | null {


### PR DESCRIPTION
## Summary
- Replace `substr()` with `substring()` in `dnd-utils.ts` and `dnd-state.ts`

Closes #197