### PR TITLE
Remove IE9/IE/Edge workarounds

### DIFF
--- a/projects/dnd/src/lib/dnd-state.spec.ts
+++ b/projects/dnd/src/lib/dnd-state.spec.ts
@@ -8,7 +8,7 @@ import {
   isExternalDrag,
   dndState,
 } from './dnd-state';
-import { CUSTOM_MIME_TYPE, JSON_MIME_TYPE, MSIE_MIME_TYPE } from './dnd-utils';
+import { CUSTOM_MIME_TYPE } from './dnd-utils';
 
 function createMockDragEvent(
   overrides: Partial<DragEvent> = {}
@@ -152,24 +152,6 @@ describe('dnd-state', () => {
         },
       } as unknown as DragEvent;
       expect(getDndType(event)).toBe('myType');
-    });
-
-    it('should return undefined for JSON MIME type on external drag', () => {
-      const event = {
-        dataTransfer: {
-          types: [JSON_MIME_TYPE],
-        },
-      } as unknown as DragEvent;
-      expect(getDndType(event)).toBeUndefined();
-    });
-
-    it('should return undefined for MSIE MIME type on external drag', () => {
-      const event = {
-        dataTransfer: {
-          types: [MSIE_MIME_TYPE],
-        },
-      } as unknown as DragEvent;
-      expect(getDndType(event)).toBeUndefined();
     });
 
     it('should return undefined when no known MIME type on external drag', () => {

--- a/projects/dnd/src/lib/dnd-state.ts
+++ b/projects/dnd/src/lib/dnd-state.ts
@@ -4,8 +4,6 @@ import {
   DROP_EFFECTS,
   filterEffects,
   getWellKnownMimeType,
-  JSON_MIME_TYPE,
-  MSIE_MIME_TYPE,
 } from './dnd-utils';
 
 export interface DndState {
@@ -97,10 +95,6 @@ export function getDndType(event: DragEvent): string | undefined {
   const mimeType = getWellKnownMimeType(event);
 
   if (mimeType === null) {
-    return undefined;
-  }
-
-  if (mimeType === MSIE_MIME_TYPE || mimeType === JSON_MIME_TYPE) {
     return undefined;
   }
 

--- a/projects/dnd/src/lib/dnd-utils.spec.ts
+++ b/projects/dnd/src/lib/dnd-utils.spec.ts
@@ -9,8 +9,6 @@ import {
   calculateDragImageOffset,
   setDragImage,
   CUSTOM_MIME_TYPE,
-  JSON_MIME_TYPE,
-  MSIE_MIME_TYPE,
 } from './dnd-utils';
 
 function createMockDragEvent(
@@ -74,20 +72,6 @@ describe('getWellKnownMimeType', () => {
     expect(getWellKnownMimeType(event)).toBeNull();
   });
 
-  it('should return MSIE_MIME_TYPE when types is falsy', () => {
-    const event = {
-      dataTransfer: { types: null },
-    } as unknown as DragEvent;
-    expect(getWellKnownMimeType(event)).toBe(MSIE_MIME_TYPE);
-  });
-
-  it('should return JSON_MIME_TYPE when present', () => {
-    const event = {
-      dataTransfer: { types: [JSON_MIME_TYPE] },
-    } as unknown as DragEvent;
-    expect(getWellKnownMimeType(event)).toBe(JSON_MIME_TYPE);
-  });
-
   it('should return custom MIME type when present', () => {
     const customType = CUSTOM_MIME_TYPE + '-mytype';
     const event = {
@@ -103,11 +87,11 @@ describe('getWellKnownMimeType', () => {
     expect(getWellKnownMimeType(event)).toBeNull();
   });
 
-  it('should return MSIE_MIME_TYPE ("Text") when present', () => {
+  it('should return null for non-custom known MIME types', () => {
     const event = {
-      dataTransfer: { types: [MSIE_MIME_TYPE] },
+      dataTransfer: { types: ['application/json'] },
     } as unknown as DragEvent;
-    expect(getWellKnownMimeType(event)).toBe(MSIE_MIME_TYPE);
+    expect(getWellKnownMimeType(event)).toBeNull();
   });
 });
 

--- a/projects/dnd/src/lib/dnd-utils.ts
+++ b/projects/dnd/src/lib/dnd-utils.ts
@@ -18,8 +18,6 @@ export type DndDragImageOffsetFunction = (
 export const DROP_EFFECTS = ['move', 'copy', 'link'] as DropEffect[];
 
 export const CUSTOM_MIME_TYPE = 'application/x-dnd';
-export const JSON_MIME_TYPE = 'application/json';
-export const MSIE_MIME_TYPE = 'Text';
 
 function mimeTypeIsCustom(mimeType: string) {
   return mimeType.substring(0, CUSTOM_MIME_TYPE.length) === CUSTOM_MIME_TYPE;
@@ -29,17 +27,8 @@ export function getWellKnownMimeType(event: DragEvent): string | null {
   if (event.dataTransfer) {
     const types = event.dataTransfer.types;
 
-    // IE 9 workaround.
-    if (!types) {
-      return MSIE_MIME_TYPE;
-    }
-
     for (let i = 0; i < types.length; i++) {
-      if (
-        types[i] === MSIE_MIME_TYPE ||
-        types[i] === JSON_MIME_TYPE ||
-        mimeTypeIsCustom(types[i])
-      ) {
+      if (mimeTypeIsCustom(types[i])) {
         return types[i];
       }
     }
@@ -53,56 +42,31 @@ export function setDragData(
   data: DragDropData,
   effectAllowed: EffectAllowed
 ): void {
-  // Internet Explorer and Microsoft Edge don't support custom mime types, see design doc:
-  // https://github.com/marceljuenemann/angular-drag-and-drop-lists/wiki/Data-Transfer-Design
   const mimeType = CUSTOM_MIME_TYPE + (data.type ? '-' + data.type : '');
 
   const dataString = JSON.stringify(data);
 
-  try {
-    event.dataTransfer?.setData(mimeType, dataString);
-  } catch (e) {
-    //   Setting a custom MIME type did not work, we are probably in IE or Edge.
-    try {
-      event.dataTransfer?.setData(JSON_MIME_TYPE, dataString);
-    } catch (e) {
-      //   We are in Internet Explorer and can only use the Text MIME type. Also note that IE
-      //   does not allow changing the cursor in the dragover event, therefore we have to choose
-      //   the one we want to display now by setting effectAllowed.
-      const effectsAllowed = filterEffects(DROP_EFFECTS, effectAllowed);
-      if (event.dataTransfer) {
-        event.dataTransfer.effectAllowed = effectsAllowed[0];
-      }
-
-      event.dataTransfer?.setData(MSIE_MIME_TYPE, dataString);
-    }
-  }
+  event.dataTransfer?.setData(mimeType, dataString);
 }
 
 export function getDropData(
   event: DragEvent,
   dragIsExternal: boolean
 ): DragDropData {
-  // check if the mime type is well known
   const mimeType = getWellKnownMimeType(event);
 
-  // drag did not originate from [dndDraggable]
   if (dragIsExternal === true) {
     if (mimeType !== null && mimeTypeIsCustom(mimeType)) {
-      // the type of content is well known and safe to handle
       return JSON.parse(event.dataTransfer?.getData(mimeType) ?? '{}');
     }
 
-    // the contained data is unknown, let user handle it
     return {};
   }
 
   if (mimeType !== null) {
-    // the type of content is well known and safe to handle
     return JSON.parse(event.dataTransfer?.getData(mimeType) ?? '{}');
   }
 
-  // the contained data is unknown, let user handle it
   return {};
 }
 


### PR DESCRIPTION
## Summary
- Remove `MSIE_MIME_TYPE`, `JSON_MIME_TYPE` constants and all IE/Edge fallback code paths
- Simplify `setDragData`, `getWellKnownMimeType`, and `getDndType`
- Update tests to match

Angular 21 does not support these browsers.

Closes #198