### PR TITLE
Fix publish workflow trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to npm
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Change release trigger from `created` to `published` so draft releases trigger the workflow when published