### PR TITLE
Fix GitHub Pages 404 on page reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:docs": "ng serve demo",
     "build:lib": "ng build dnd",
     "watch:lib": "ng build dnd --watch --configuration development",
-    "build:docs": "ng build demo --configuration production",
+    "build:docs": "ng build demo --configuration production --base-href /ngx-drag-drop/ && cp docs/index.html docs/404.html",
     "watch:docs": "ng build demo --watch --configuration development",
     "publish:stable": "npm publish ./dist/ngx-drag-drop",
     "publish:next": "npm publish ./dist/ngx-drag-drop --tag next",

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>NgxDragDrop</title>
-    <base href="." />
+    <base href="/" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     <link href="favicon.ico" rel="icon" type="image/x-icon" />
     <link href="https://fonts.gstatic.com" rel="preconnect" />


### PR DESCRIPTION
## Summary
- Set `--base-href /ngx-drag-drop/` in the docs build
- Copy `index.html` to `404.html` so GitHub Pages serves the SPA for all routes
- Change default `base href` in `index.html` from `.` to `/`