### PR TITLE
Upgrade prettier to v3 and TypeScript to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "@vitest/coverage-v8": "4.1.2",
     "jsdom": "29.0.1",
     "ng-packagr": "21.2.1",
-    "prettier": "2.8.8",
-    "typescript": "5.9.3",
+    "prettier": "3.5.3",
+    "typescript": "6.0.2",
     "vitest": "4.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,16 +56,16 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: 2.3.1
-        version: 2.3.1(@angular/build@21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.8)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3))))
+        version: 2.3.1(@angular/build@21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2))(postcss@8.5.8)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3))))
       '@angular/build':
         specifier: 21.2.4
-        version: 21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.8)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3)))
+        version: 21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2))(postcss@8.5.8)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3)))
       '@angular/cli':
         specifier: 21.2.4
         version: 21.2.4(@types/node@24.12.0)(chokidar@5.0.0)
       '@angular/compiler-cli':
         specifier: 21.2.6
-        version: 21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3)
+        version: 21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2)
       '@types/node':
         specifier: 24.12.0
         version: 24.12.0
@@ -77,13 +77,13 @@ importers:
         version: 29.0.1
       ng-packagr:
         specifier: 21.2.1
-        version: 21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+        version: 21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2)
       prettier:
-        specifier: 2.8.8
-        version: 2.8.8
+        specifier: 3.5.3
+        version: 3.5.3
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.2
+        version: 6.0.2
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3))
@@ -2510,9 +2510,9 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
     hasBin: true
 
   proc-log@6.1.0:
@@ -2826,8 +2826,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3123,12 +3123,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.3.1(@angular/build@21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.8)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3))))':
+  '@analogjs/vite-plugin-angular@2.3.1(@angular/build@21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2))(postcss@8.5.8)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3))))':
     dependencies:
       tinyglobby: 0.2.15
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular/build': 21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.8)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3)))
+      '@angular/build': 21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2))(postcss@8.5.8)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3)))
 
   '@angular-devkit/architect@0.2102.4(chokidar@5.0.0)':
     dependencies:
@@ -3163,12 +3163,12 @@ snapshots:
       '@angular/core': 21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)
       tslib: 2.8.1
 
-  '@angular/build@21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3))(postcss@8.5.8)(tslib@2.8.1)(typescript@5.9.3)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3)))':
+  '@angular/build@21.2.4(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(@angular/compiler@21.2.6)(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@types/node@24.12.0)(chokidar@5.0.0)(less@4.6.4)(ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2))(postcss@8.5.8)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3)))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.4(chokidar@5.0.0)
       '@angular/compiler': 21.2.6
-      '@angular/compiler-cli': 21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3)
+      '@angular/compiler-cli': 21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2)
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-split-export-declaration': 7.24.7
@@ -3192,7 +3192,7 @@ snapshots:
       source-map-support: 0.5.21
       tinyglobby: 0.2.15
       tslib: 2.8.1
-      typescript: 5.9.3
+      typescript: 6.0.2
       undici: 7.24.4
       vite: 7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3)
       watchpack: 2.5.1
@@ -3201,7 +3201,7 @@ snapshots:
       '@angular/platform-browser': 21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))
       less: 4.6.4
       lmdb: 3.5.1
-      ng-packagr: 21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3)
+      ng-packagr: 21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2)
       postcss: 8.5.8
       vitest: 4.1.2(@types/node@24.12.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@24.12.0)(less@4.6.4)(sass@1.97.3))
     transitivePeerDependencies:
@@ -3258,7 +3258,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3)':
+  '@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2)':
     dependencies:
       '@angular/compiler': 21.2.6
       '@babel/core': 7.29.0
@@ -3270,7 +3270,7 @@ snapshots:
       tslib: 2.8.1
       yargs: 18.0.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5187,10 +5187,10 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3))(tslib@2.8.1)(typescript@5.9.3):
+  ng-packagr@21.2.1(@angular/compiler-cli@21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2))(tslib@2.8.1)(typescript@6.0.2):
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular/compiler-cli': 21.2.6(@angular/compiler@21.2.6)(typescript@5.9.3)
+      '@angular/compiler-cli': 21.2.6(@angular/compiler@21.2.6)(typescript@6.0.2)
       '@rollup/plugin-json': 6.1.0(rollup@4.60.0)
       '@rollup/wasm-node': 4.60.0
       ajv: 8.18.0
@@ -5207,12 +5207,12 @@ snapshots:
       ora: 9.3.0
       piscina: 5.1.4
       postcss: 8.5.8
-      rollup-plugin-dts: 6.4.1(rollup@4.60.0)(typescript@5.9.3)
+      rollup-plugin-dts: 6.4.1(rollup@4.60.0)(typescript@6.0.2)
       rxjs: 7.8.2
       sass: 1.97.3
       tinyglobby: 0.2.15
       tslib: 2.8.1
-      typescript: 5.9.3
+      typescript: 6.0.2
     optionalDependencies:
       rollup: 4.60.0
 
@@ -5412,7 +5412,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@2.8.8: {}
+  prettier@3.5.3: {}
 
   proc-log@6.1.0: {}
 
@@ -5484,14 +5484,14 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.4
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.4
 
-  rollup-plugin-dts@6.4.1(rollup@4.60.0)(typescript@5.9.3):
+  rollup-plugin-dts@6.4.1(rollup@4.60.0)(typescript@6.0.2):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
       convert-source-map: 2.0.0
       magic-string: 0.30.21
       rollup: 4.60.0
-      typescript: 5.9.3
+      typescript: 6.0.2
     optionalDependencies:
       '@babel/code-frame': 7.29.0
 
@@ -5792,7 +5792,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.16.0: {}
 

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -9,9 +9,9 @@
   </button>
   <mat-menu #issueMenu="matMenu">
     @for (demo of issueDemos; track demo.issue) {
-    <button (click)="onIssueDemoClick(demo.issue)" mat-menu-item>
-      {{ demo.label }}
-    </button>
+      <button (click)="onIssueDemoClick(demo.issue)" mat-menu-item>
+        {{ demo.label }}
+      </button>
     }
   </mat-menu>
 
@@ -21,13 +21,16 @@
 </mat-toolbar>
 
 @if (activeTab$ | async; as activeTab) {
-<nav [tabPanel]="tabPanel" mat-tab-nav-bar>
-  @for (tab of tabs; track tab) {
-  <a [active]="activeTab === tab" (click)="onTabLinkClick(tab)" mat-tab-link>
-    {{ tab }}
-  </a>
-  }
-</nav>
+  <nav [tabPanel]="tabPanel" mat-tab-nav-bar>
+    @for (tab of tabs; track tab) {
+      <a
+        [active]="activeTab === tab"
+        (click)="onTabLinkClick(tab)"
+        mat-tab-link>
+        {{ tab }}
+      </a>
+    }
+  </nav>
 }
 
 <mat-tab-nav-panel #tabPanel class="flex-grow-1 pt-3 overflow-auto">

--- a/projects/demo/src/app/issue-195/issue-195.component.html
+++ b/projects/demo/src/app/issue-195/issue-195.component.html
@@ -29,26 +29,28 @@
 </div>
 
 @if (lastDropEvent) {
-<div class="result">
-  <div>
-    <strong
-      >Dropzone received dropEffect: {{ lastDropEvent.dropEffect }}</strong
-    >
-    <span
-      [class.pass]="lastDropEvent.dropEffect === 'link'"
-      [class.fail]="lastDropEvent.dropEffect !== 'link'">
-      {{
-        lastDropEvent.dropEffect === 'link' ? 'PASS' : 'FAIL — expected "link"'
-      }}
-    </span>
+  <div class="result">
+    <div>
+      <strong
+        >Dropzone received dropEffect: {{ lastDropEvent.dropEffect }}</strong
+      >
+      <span
+        [class.pass]="lastDropEvent.dropEffect === 'link'"
+        [class.fail]="lastDropEvent.dropEffect !== 'link'">
+        {{
+          lastDropEvent.dropEffect === 'link'
+            ? 'PASS'
+            : 'FAIL — expected "link"'
+        }}
+      </span>
+    </div>
+    <div>
+      <strong>Draggable fired effect: {{ dragEffect }}</strong>
+      <span
+        [class.pass]="dragEffect === 'link'"
+        [class.fail]="dragEffect !== 'link'">
+        {{ dragEffect === 'link' ? 'PASS' : 'FAIL — expected "link"' }}
+      </span>
+    </div>
   </div>
-  <div>
-    <strong>Draggable fired effect: {{ dragEffect }}</strong>
-    <span
-      [class.pass]="dragEffect === 'link'"
-      [class.fail]="dragEffect !== 'link'">
-      {{ dragEffect === 'link' ? 'PASS' : 'FAIL — expected "link"' }}
-    </span>
-  </div>
-</div>
 }

--- a/projects/demo/src/app/list/list.component.html
+++ b/projects/demo/src/app/list/list.component.html
@@ -16,28 +16,28 @@
         </mat-list-item>
 
         @for (item of draggableListLeft; track item) {
-        <mat-list-item
-          [dndDisableIf]="item.disable"
-          [dndDraggable]="item"
-          [dndEffectAllowed]="item.effectAllowed"
-          (dndCanceled)="onDragged(item, draggableListLeft, 'none')"
-          (dndCopied)="onDragged(item, draggableListLeft, 'copy')"
-          (dndEnd)="onDragEnd($event)"
-          (dndLinked)="onDragged(item, draggableListLeft, 'link')"
-          (dndMoved)="onDragged(item, draggableListLeft, 'move')"
-          (dndStart)="onDragStart($event)"
-          class="border rounded-1 bg-white">
-          @if (item.handle) {
-          <div
-            class="drag-handle align-self-center mx-3 my-0"
-            dndHandle
-            matListItemIcon>
-            <mat-icon fontIcon="drag_handle"></mat-icon>
-          </div>
-          }
-          <span matListItemTitle>{{ item.content }}</span>
-          <span matListItemLine>effectAllowed: {{ item.effectAllowed }}</span>
-        </mat-list-item>
+          <mat-list-item
+            [dndDisableIf]="item.disable"
+            [dndDraggable]="item"
+            [dndEffectAllowed]="item.effectAllowed"
+            (dndCanceled)="onDragged(item, draggableListLeft, 'none')"
+            (dndCopied)="onDragged(item, draggableListLeft, 'copy')"
+            (dndEnd)="onDragEnd($event)"
+            (dndLinked)="onDragged(item, draggableListLeft, 'link')"
+            (dndMoved)="onDragged(item, draggableListLeft, 'move')"
+            (dndStart)="onDragStart($event)"
+            class="border rounded-1 bg-white">
+            @if (item.handle) {
+              <div
+                class="drag-handle align-self-center mx-3 my-0"
+                dndHandle
+                matListItemIcon>
+                <mat-icon fontIcon="drag_handle"></mat-icon>
+              </div>
+            }
+            <span matListItemTitle>{{ item.content }}</span>
+            <span matListItemLine>effectAllowed: {{ item.effectAllowed }}</span>
+          </mat-list-item>
         }
       </mat-list>
     </div>
@@ -57,28 +57,28 @@
           dndPlaceholderRef>
         </mat-list-item>
         @for (item of draggableListRight; track item) {
-        <mat-list-item
-          [dndDisableIf]="item.disable"
-          [dndDraggable]="item"
-          [dndEffectAllowed]="item.effectAllowed"
-          (dndCanceled)="onDragged(item, draggableListRight, 'none')"
-          (dndCopied)="onDragged(item, draggableListRight, 'copy')"
-          (dndEnd)="onDragEnd($event)"
-          (dndLinked)="onDragged(item, draggableListRight, 'link')"
-          (dndMoved)="onDragged(item, draggableListRight, 'move')"
-          (dndStart)="onDragStart($event)"
-          class="border rounded-1 bg-white">
-          @if (item.handle) {
-          <div
-            class="drag-handle align-self-center mx-3 my-0"
-            dndHandle
-            matListItemIcon>
-            <mat-icon fontIcon="drag_handle"></mat-icon>
-          </div>
-          }
-          <span matListItemTitle>{{ item.content }}</span>
-          <span matListItemLine>effectAllowed: {{ item.effectAllowed }}</span>
-        </mat-list-item>
+          <mat-list-item
+            [dndDisableIf]="item.disable"
+            [dndDraggable]="item"
+            [dndEffectAllowed]="item.effectAllowed"
+            (dndCanceled)="onDragged(item, draggableListRight, 'none')"
+            (dndCopied)="onDragged(item, draggableListRight, 'copy')"
+            (dndEnd)="onDragEnd($event)"
+            (dndLinked)="onDragged(item, draggableListRight, 'link')"
+            (dndMoved)="onDragged(item, draggableListRight, 'move')"
+            (dndStart)="onDragStart($event)"
+            class="border rounded-1 bg-white">
+            @if (item.handle) {
+              <div
+                class="drag-handle align-self-center mx-3 my-0"
+                dndHandle
+                matListItemIcon>
+                <mat-icon fontIcon="drag_handle"></mat-icon>
+              </div>
+            }
+            <span matListItemTitle>{{ item.content }}</span>
+            <span matListItemLine>effectAllowed: {{ item.effectAllowed }}</span>
+          </mat-list-item>
         }
       </mat-list>
     </div>

--- a/projects/demo/src/app/native/native.component.html
+++ b/projects/demo/src/app/native/native.component.html
@@ -51,13 +51,16 @@
             dndDropzone>
             <div>
               @if (lastDropEvent) {
-              <pre>Event: {{ lastDropEvent | json }}</pre>
-              } @if (lastDropTypes && lastDropTypes.length) {
-              <pre>Types: {{ lastDropTypes | json }}</pre>
-              } @if (lastDropFiles && lastDropFiles.length) {
-              <pre>Files: {{ lastDropFiles | json }}</pre>
-              } @if (lastDropItems && lastDropItems.length) {
-              <pre>Items: {{ lastDropItems | json }}</pre>
+                <pre>Event: {{ lastDropEvent | json }}</pre>
+              }
+              @if (lastDropTypes && lastDropTypes.length) {
+                <pre>Types: {{ lastDropTypes | json }}</pre>
+              }
+              @if (lastDropFiles && lastDropFiles.length) {
+                <pre>Files: {{ lastDropFiles | json }}</pre>
+              }
+              @if (lastDropItems && lastDropItems.length) {
+                <pre>Items: {{ lastDropItems | json }}</pre>
               }
             </div>
           </div>

--- a/projects/demo/src/app/nested/nested.component.html
+++ b/projects/demo/src/app/nested/nested.component.html
@@ -4,42 +4,44 @@
     </mat-card>
 
     @for (item of list; track item) {
-    <mat-card
-      appearance="raised"
-      [dndDisableIf]="!!item.disable"
-      [dndDraggable]="item"
-      (dndCanceled)="onDragged(item, list, 'none')"
-      (dndCopied)="onDragged(item, list, 'copy')"
-      (dndEnd)="onDragEnd($event)"
-      (dndLinked)="onDragged(item, list, 'link')"
-      (dndMoved)="onDragged(item, list, 'move')"
-      (dndStart)="onDragStart($event)"
-      dndEffectAllowed="move">
-      <mat-card-header class="p-2">
-        @if (item.handle) {
-        <div class="drag-handle me-2 text-muted">
-          <mat-icon dndHandle mat-list-icon>drag_handle </mat-icon>
-        </div>
-        }
-        {{ item.content }}
-      </mat-card-header>
-      <mat-card-content class="d-flex align-items-start gap-2 flex-column p-2">
-        @if (!!item.customDragImage) {
-        <div dndDragImageRef>MY_CUSTOM_DRAG_IMAGE</div>
-        } @if (item.children) {
-        <div
-          (dndDrop)="onDrop($event, item.children)"
-          class="flex-column p-2 gap-2 rounded-2"
-          dndDropzone>
-          <ng-container
-            *ngTemplateOutlet="
-              recursiveList;
-              context: { $implicit: item.children }
-            "></ng-container>
-        </div>
-        }
-      </mat-card-content>
-    </mat-card>
+      <mat-card
+        appearance="raised"
+        [dndDisableIf]="!!item.disable"
+        [dndDraggable]="item"
+        (dndCanceled)="onDragged(item, list, 'none')"
+        (dndCopied)="onDragged(item, list, 'copy')"
+        (dndEnd)="onDragEnd($event)"
+        (dndLinked)="onDragged(item, list, 'link')"
+        (dndMoved)="onDragged(item, list, 'move')"
+        (dndStart)="onDragStart($event)"
+        dndEffectAllowed="move">
+        <mat-card-header class="p-2">
+          @if (item.handle) {
+            <div class="drag-handle me-2 text-muted">
+              <mat-icon dndHandle mat-list-icon>drag_handle </mat-icon>
+            </div>
+          }
+          {{ item.content }}
+        </mat-card-header>
+        <mat-card-content
+          class="d-flex align-items-start gap-2 flex-column p-2">
+          @if (!!item.customDragImage) {
+            <div dndDragImageRef>MY_CUSTOM_DRAG_IMAGE</div>
+          }
+          @if (item.children) {
+            <div
+              (dndDrop)="onDrop($event, item.children)"
+              class="flex-column p-2 gap-2 rounded-2"
+              dndDropzone>
+              <ng-container
+                *ngTemplateOutlet="
+                  recursiveList;
+                  context: { $implicit: item.children }
+                "></ng-container>
+            </div>
+          }
+        </mat-card-content>
+      </mat-card>
     }
   </ng-template>
 

--- a/projects/demo/src/app/nested/nested.component.scss
+++ b/projects/demo/src/app/nested/nested.component.scss
@@ -4,7 +4,9 @@
 }
 
 mat-card {
-  transition: transform 200ms, opacity 200ms;
+  transition:
+    transform 200ms,
+    opacity 200ms;
 }
 
 mat-card-header {

--- a/projects/demo/src/app/shadow-dom/shadow-dom.component.html
+++ b/projects/demo/src/app/shadow-dom/shadow-dom.component.html
@@ -2,25 +2,25 @@
   <div class="placeholder" dndPlaceholderRef></div>
 
   @for (item of list; track item) {
-  <div
-    [dndDraggable]="item"
-    dndEffectAllowed="move"
-    (dndMoved)="onDragged(item, list, 'move')"
-    class="drag-item">
-    <div class="drag-item-header">{{ item.content }}</div>
-    @if (item.children) {
     <div
-      (dndDrop)="onDrop($event, item.children)"
-      class="nested-dropzone"
-      dndDropzone>
-      <ng-container
-        *ngTemplateOutlet="
-          recursiveList;
-          context: { $implicit: item.children }
-        "></ng-container>
+      [dndDraggable]="item"
+      dndEffectAllowed="move"
+      (dndMoved)="onDragged(item, list, 'move')"
+      class="drag-item">
+      <div class="drag-item-header">{{ item.content }}</div>
+      @if (item.children) {
+        <div
+          (dndDrop)="onDrop($event, item.children)"
+          class="nested-dropzone"
+          dndDropzone>
+          <ng-container
+            *ngTemplateOutlet="
+              recursiveList;
+              context: { $implicit: item.children }
+            "></ng-container>
+        </div>
+      }
     </div>
-    }
-  </div>
   }
 </ng-template>
 

--- a/projects/demo/src/app/simple/simple.component.html
+++ b/projects/demo/src/app/simple/simple.component.html
@@ -2,27 +2,28 @@
   <div class="row gap-3 gap-sm-0">
     <div class="d-flex flex-column col gap-2">
       @for (draggable of draggables; track draggable) {
-      <mat-card
-        appearance="raised"
-        [dndDisableIf]="draggable.disable"
-        [dndDraggable]="draggable.content"
-        [dndEffectAllowed]="draggable.effectAllowed"
-        (dndCanceled)="onDragged($event, 'none')"
-        (dndCopied)="onDragged($event, 'copy')"
-        (dndEnd)="onDragEnd($event)"
-        (dndLinked)="onDragged($event, 'link')"
-        (dndMoved)="onDragged($event, 'move')"
-        (dndStart)="onDragStart($event)">
-        <mat-card-content class="d-flex flex-column gap-2">
-          @if (draggable.handle) {
-          <div class="drag-handle" dndHandle>
-            <mat-icon fontIcon="drag_handle" mat-list-icon> </mat-icon>
-          </div>
-          } draggable ({{ draggable.effectAllowed }})
-          <span [hidden]="!draggable.handle"> only with handle</span>
-          <span [hidden]="!draggable.disable"> DISABLED</span>
-        </mat-card-content>
-      </mat-card>
+        <mat-card
+          appearance="raised"
+          [dndDisableIf]="draggable.disable"
+          [dndDraggable]="draggable.content"
+          [dndEffectAllowed]="draggable.effectAllowed"
+          (dndCanceled)="onDragged($event, 'none')"
+          (dndCopied)="onDragged($event, 'copy')"
+          (dndEnd)="onDragEnd($event)"
+          (dndLinked)="onDragged($event, 'link')"
+          (dndMoved)="onDragged($event, 'move')"
+          (dndStart)="onDragStart($event)">
+          <mat-card-content class="d-flex flex-column gap-2">
+            @if (draggable.handle) {
+              <div class="drag-handle" dndHandle>
+                <mat-icon fontIcon="drag_handle" mat-list-icon> </mat-icon>
+              </div>
+            }
+            draggable ({{ draggable.effectAllowed }})
+            <span [hidden]="!draggable.handle"> only with handle</span>
+            <span [hidden]="!draggable.disable"> DISABLED</span>
+          </mat-card-content>
+        </mat-card>
       }
 
       <mat-card
@@ -38,11 +39,12 @@
         (dndStart)="onDragStart($event)">
         <mat-card-content class="d-flex flex-column gap-2">
           @if (draggableWithDragImage.handle) {
-          <div class="drag-handle">
-            <mat-icon dndHandle fontIcon="drag_handle" mat-list-icon>
-            </mat-icon>
-          </div>
-          } draggable ({{ draggableWithDragImage.effectAllowed }})
+            <div class="drag-handle">
+              <mat-icon dndHandle fontIcon="drag_handle" mat-list-icon>
+              </mat-icon>
+            </div>
+          }
+          draggable ({{ draggableWithDragImage.effectAllowed }})
           <span [hidden]="!draggableWithDragImage.handle"
             >only with handle</span
           >
@@ -114,7 +116,7 @@
             dndDragoverClass="custom-drag-over"
             dndDropzone>
             @if (lastDropEvent) {
-            <pre>{{ lastDropEvent | json }}</pre>
+              <pre>{{ lastDropEvent | json }}</pre>
             }
           </section>
         </mat-card-content>

--- a/projects/demo/src/app/tree/tree.component.html
+++ b/projects/demo/src/app/tree/tree.component.html
@@ -5,29 +5,29 @@
       dndPlaceholderRef />
 
     @for (item of list; track item) {
-    <div class="">
-      <mat-list-item
-        [dndDraggable]="item"
-        dndEffectAllowed="move"
-        (dndMoved)="onDragged(item, list, 'move')"
-        class="border bg-white ms-n3">
-        <span matListItemTitle>{{ item.content }}</span>
-      </mat-list-item>
-      @if (item.children) {
-      <mat-list
-        (dndDrop)="onDrop($event, item.children)"
-        class="d-flex flex-column bg-light pt-2 pb-0 ps-2"
-        style="min-height: unset"
-        dndDropzone
-        dndEffectAllowed="move">
-        <ng-container
-          *ngTemplateOutlet="
-            recursiveList;
-            context: { $implicit: item.children }
-          " />
-      </mat-list>
-      }
-    </div>
+      <div class="">
+        <mat-list-item
+          [dndDraggable]="item"
+          dndEffectAllowed="move"
+          (dndMoved)="onDragged(item, list, 'move')"
+          class="border bg-white ms-n3">
+          <span matListItemTitle>{{ item.content }}</span>
+        </mat-list-item>
+        @if (item.children) {
+          <mat-list
+            (dndDrop)="onDrop($event, item.children)"
+            class="d-flex flex-column bg-light pt-2 pb-0 ps-2"
+            style="min-height: unset"
+            dndDropzone
+            dndEffectAllowed="move">
+            <ng-container
+              *ngTemplateOutlet="
+                recursiveList;
+                context: { $implicit: item.children }
+              " />
+          </mat-list>
+        }
+      </div>
     }
   </ng-template>
 

--- a/projects/demo/src/app/typed/typed.component.html
+++ b/projects/demo/src/app/typed/typed.component.html
@@ -12,14 +12,14 @@
           dndPlaceholderRef>
         </mat-list-item>
         @for (fruit of fruits; track trackByFruit(i, fruit); let i = $index) {
-        <mat-list-item
-          [dndDraggable]="fruit"
-          [dndType]="fruit.type"
-          (dndMoved)="onDragged(i, fruit, fruits)"
-          class="border rounded-1 bg-white"
-          dndEffectAllowed="move">
-          <span matListItemTitle>{{ fruit.type }} {{ fruit.id }}</span>
-        </mat-list-item>
+          <mat-list-item
+            [dndDraggable]="fruit"
+            [dndType]="fruit.type"
+            (dndMoved)="onDragged(i, fruit, fruits)"
+            class="border rounded-1 bg-white"
+            dndEffectAllowed="move">
+            <span matListItemTitle>{{ fruit.type }} {{ fruit.id }}</span>
+          </mat-list-item>
         }
       </mat-list>
     </div>
@@ -36,14 +36,14 @@
           dndPlaceholderRef>
         </mat-list-item>
         @for (apple of apples; track trackByFruit(i, apple); let i = $index) {
-        <mat-list-item
-          [dndDraggable]="apple"
-          [dndType]="apple.type"
-          (dndMoved)="onDragged(i, apple, apples)"
-          class="border rounded-1 bg-white"
-          dndEffectAllowed="move">
-          <span matListItemTitle>{{ apple.type }} {{ apple.id }}</span>
-        </mat-list-item>
+          <mat-list-item
+            [dndDraggable]="apple"
+            [dndType]="apple.type"
+            (dndMoved)="onDragged(i, apple, apples)"
+            class="border rounded-1 bg-white"
+            dndEffectAllowed="move">
+            <span matListItemTitle>{{ apple.type }} {{ apple.id }}</span>
+          </mat-list-item>
         }
       </mat-list>
     </div>
@@ -59,16 +59,19 @@
           class="dndPlaceholder border rounded-1 bg-warning bg-gradient"
           dndPlaceholderRef>
         </mat-list-item>
-        @for (banana of bananas; track trackByFruit(i, banana); let i = $index)
-        {
-        <mat-list-item
-          [dndDraggable]="banana"
-          [dndType]="banana.type"
-          (dndMoved)="onDragged(i, banana, bananas)"
-          class="border rounded-1 bg-white"
-          dndEffectAllowed="move">
-          <span matListItemTitle>{{ banana.type }} {{ banana.id }}</span>
-        </mat-list-item>
+        @for (
+          banana of bananas;
+          track trackByFruit(i, banana);
+          let i = $index
+        ) {
+          <mat-list-item
+            [dndDraggable]="banana"
+            [dndType]="banana.type"
+            (dndMoved)="onDragged(i, banana, bananas)"
+            class="border rounded-1 bg-white"
+            dndEffectAllowed="move">
+            <span matListItemTitle>{{ banana.type }} {{ banana.id }}</span>
+          </mat-list-item>
         }
       </mat-list>
     </div>

--- a/projects/demo/src/index.html
+++ b/projects/demo/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/projects/demo/src/styles.scss
+++ b/projects/demo/src/styles.scss
@@ -1,4 +1,4 @@
-@import 'node_modules/bootstrap/scss/bootstrap.scss';
+@import 'bootstrap/scss/bootstrap.scss';
 
 .drag-handle {
   border: 1px solid #ddd;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
@@ -14,8 +13,8 @@
     "sourceMap": true,
     "paths": {
       "ngx-drag-drop": [
-        "dist/ngx-drag-drop/ngx-drag-drop",
-        "dist/ngx-drag-drop"
+        "./dist/ngx-drag-drop/ngx-drag-drop",
+        "./dist/ngx-drag-drop"
       ]
     },
     "declaration": false,


### PR DESCRIPTION
## Summary
- Upgrade prettier from 2.8.8 to 3.5.3
- Upgrade TypeScript from 5.9.3 to 6.0.2
- Remove deprecated `baseUrl` from tsconfig, use relative paths in `paths`
- Fix bootstrap scss import for pnpm strict `node_modules`
- Reformat codebase with prettier v3