### PR TITLE
Replace mobile-drag-drop with @dragdroptouch/drag-drop-touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,31 +311,20 @@ export declare class DndDropzoneDirective {
 }
 ```
 
-## Touch support
+## Touch support (experimental)
 
-Install the `mobile-drag-drop` module available on npm.
+This library uses the native HTML5 Drag and Drop API, which is **not supported on most mobile browsers** (including iOS Safari). Touch support requires a polyfill that translates touch events into drag events. This approach has known limitations and the experience may not be reliable on all devices.
 
-Add the following lines to your js code
+To enable basic touch support, install the `@dragdroptouch/drag-drop-touch` polyfill:
 
 ```JS
-import { polyfill } from 'mobile-drag-drop';
-// optional import of scroll behaviour
-import { scrollBehaviourDragImageTranslateOverride } from "mobile-drag-drop/scroll-behaviour";
+import { enableDragDropTouch } from "@dragdroptouch/drag-drop-touch";
 
-polyfill( {
-  // use this to make use of the scroll behaviour
-  dragImageTranslateOverride: scrollBehaviourDragImageTranslateOverride
-} );
-
-// workaround to make scroll prevent work in iOS Safari >= 10
-try {
-  window.addEventListener( "touchmove", function() { }, { passive: false } );
-}
-catch(e){}
+enableDragDropTouch();
 ```
 
 For more info on the polyfill check it out on GitHub
-https://github.com/timruffles/mobile-drag-drop
+https://github.com/drag-drop-touch-js/dragdroptouch
 
 ## Known issues
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "@angular/platform-browser": "^21.2.6",
     "@angular/platform-browser-dynamic": "^21.2.6",
     "@angular/router": "^21.2.6",
+    "@dragdroptouch/drag-drop-touch": "^2.0.3",
     "bootstrap": "^5.3.8",
-    "mobile-drag-drop": "^3.0.0-beta.0",
     "rxjs": "~7.8.2",
     "tslib": "^2.3.0",
     "zone.js": "~0.16.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,12 @@ importers:
       '@angular/router':
         specifier: ^21.2.6
         version: 21.2.6(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.6(@angular/animations@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.6(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.6(@angular/compiler@21.2.6)(rxjs@7.8.2)(zone.js@0.16.1)))(rxjs@7.8.2)
+      '@dragdroptouch/drag-drop-touch':
+        specifier: ^2.0.3
+        version: 2.0.3
       bootstrap:
         specifier: ^5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
-      mobile-drag-drop:
-        specifier: ^3.0.0-beta.0
-        version: 3.0.0-rc.0
       rxjs:
         specifier: ~7.8.2
         version: 7.8.2
@@ -456,6 +456,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dragdroptouch/drag-drop-touch@2.0.3':
+    resolution: {integrity: sha512-4Yv1+S2Yxs/5iYLZyZYobAlCvIJPN6TYBjvJDyI9kH30GfBxA+ffHgKK2l00EyyBlUpB10j8BWAbRsgXRtBbPw==}
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -2296,9 +2299,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  mobile-drag-drop@3.0.0-rc.0:
-    resolution: {integrity: sha512-f8wIDTbBYLBW/+5sei1cqUE+StyDpf/LP+FRZELlVX6tmOOmELk84r3wh1z3woxCB9G5octhF06K5COvFjGgqg==}
-
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -3484,6 +3484,8 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dragdroptouch/drag-drop-touch@2.0.3': {}
 
   '@emnapi/core@1.9.1':
     dependencies:
@@ -5151,8 +5153,6 @@ snapshots:
       minipass: 7.1.3
 
   mkdirp@3.0.1: {}
-
-  mobile-drag-drop@3.0.0-rc.0: {}
 
   mrmime@2.0.1: {}
 

--- a/projects/demo/src/dragdroptouch.d.ts
+++ b/projects/demo/src/dragdroptouch.d.ts
@@ -1,0 +1,7 @@
+declare module '@dragdroptouch/drag-drop-touch' {
+  export function enableDragDropTouch(
+    dragRoot?: Element,
+    dropRoot?: Element,
+    options?: Record<string, unknown>
+  ): void;
+}

--- a/projects/demo/src/polyfills.ts
+++ b/projects/demo/src/polyfills.ts
@@ -45,20 +45,10 @@
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
-import { polyfill } from 'mobile-drag-drop';
-// optional import of scroll behaviour
-import { scrollBehaviourDragImageTranslateOverride } from 'mobile-drag-drop/scroll-behaviour';
+import { enableDragDropTouch } from '@dragdroptouch/drag-drop-touch';
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
 import 'zone.js'; // Included with Angular CLI.
 
-// options are optional ;)
-polyfill({
-  // use this to make use of the scroll behaviour
-  dragImageTranslateOverride: scrollBehaviourDragImageTranslateOverride,
-});
-
-window.addEventListener('touchmove', function () {
-  // workaround to make scroll prevent work in iOS Safari > 10
-});
+enableDragDropTouch();


### PR DESCRIPTION
## Summary
- Replace unmaintained `mobile-drag-drop` polyfill with `@dragdroptouch/drag-drop-touch` (actively maintained, last published June 2025)
- Mark touch support as experimental in README since HTML5 DnD API is fundamentally unsupported on mobile browsers
- Add type declaration for the new polyfill (no bundled types)