### PR TITLE
Bump version to 21.0.6

### DIFF
--- a/projects/dnd/package.json
+++ b/projects/dnd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-drop",
-  "version": "21.0.5",
+  "version": "21.0.6",
   "description": "Angular directives using the native HTML Drag And Drop API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Version bump for 21.0.6 release.

### Changes since v21.0.5
- Fix nested dropzone flickering and stale placeholders (#235)
- Migrate from npm to pnpm (#226)
- Replace `mobile-drag-drop` with `@dragdroptouch/drag-drop-touch` (#237)
- Upgrade prettier to v3 and TypeScript to v6 (#236)
- Update Angular to 21.2.6 and zone.js to 0.16.1 (#225)
- CI: split workflows, update GitHub Actions (#220, #223, #224, #228, #231)
- Add Renovate for dependency management (#210)