### PR TITLE
feat: update library to Angular 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Starting with v13, the library major version matches the Angular major version.
 
 | Angular | ngx-drag-drop |
 | ------- | ------------- |
+| 22.x    | 22.x          |
 | 21.x    | 21.x          |
 | 20.x    | 20.x          |
 | 19.x    | 19.x          |

--- a/projects/dnd/package.json
+++ b/projects/dnd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-drag-drop",
-  "version": "21.0.6",
+  "version": "22.0.0",
   "description": "Angular directives using the native HTML Drag And Drop API",
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "touch"
   ],
   "peerDependencies": {
-    "@angular/common": ">=21.0.0",
-    "@angular/core": ">=21.0.0"
+    "@angular/common": ">=22.0.0",
+    "@angular/core": ">=22.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/projects/dnd/src/lib/dnd-dropzone.directive.ts
+++ b/projects/dnd/src/lib/dnd-dropzone.directive.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   EventEmitter,
   HostListener,
+  inject,
   Input,
   NgZone,
   OnDestroy,
@@ -38,7 +39,7 @@ export interface DndDropEvent {
 
 @Directive({ selector: '[dndPlaceholderRef]', standalone: true })
 export class DndPlaceholderRefDirective implements OnInit {
-  constructor(public readonly elementRef: ElementRef<HTMLElement>) {}
+  readonly elementRef: ElementRef<HTMLElement> = inject(ElementRef);
 
   ngOnInit() {
     // placeholder has to be "invisible" to the cursor, or it would interfere with the dragover detection for the same dropzone
@@ -75,11 +76,9 @@ export class DndDropzoneDirective implements AfterViewInit, OnDestroy {
 
   private enterCount: number = 0;
 
-  constructor(
-    private ngZone: NgZone,
-    private elementRef: ElementRef,
-    private renderer: Renderer2
-  ) {}
+  private ngZone = inject(NgZone);
+  private elementRef: ElementRef = inject(ElementRef);
+  private renderer = inject(Renderer2);
 
   @Input() set dndDisableIf(value: boolean) {
     this.disabled = value;


### PR DESCRIPTION
## Summary

- Bumps library version `21.0.6` → `22.0.0`
- Updates peer dependencies from `>=21.0.0` to `>=22.0.0`
- Migrates `DndDropzoneDirective` and `DndPlaceholderRefDirective` from constructor injection to `inject()`, consistent with the rest of the library
- Adds Angular 22.x row to the README compatibility table

## Test plan

- [x] `pnpm run test` — 64 tests pass
- [x] `pnpm run build:lib` — builds cleanly with Angular 22 + ng-packagr 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)